### PR TITLE
Log audit results via POST

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,6 +174,28 @@
         });
       });
       doc.save(`TWC_Audit_${auditor.id}_${Date.now()}.pdf`);
+
+      const payload = {
+        auditor,
+        store: { name: storeName, id: storeId },
+        scores: resp,
+        overallScore: score,
+        images: sectionImages,
+        timestamp: Date.now()
+      };
+
+      fetch(LOG_ENDPOINT, {
+        method: 'POST',
+        body: JSON.stringify(payload)
+      }).then(r => {
+        if (r.ok) {
+          alert('Submission logged successfully');
+        } else {
+          r.text().then(t => alert('Failed to log submission: ' + t));
+        }
+      }).catch(err => {
+        alert('Error logging submission: ' + err.message);
+      });
     };
 
     function computeScore(){


### PR DESCRIPTION
## Summary
- post audit data to `LOG_ENDPOINT`
- handle success and error with alerts

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6864269b5e54832486003e1457ff9457